### PR TITLE
feat: basic GitHub Pages + Vercel CI/CD demos

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,0 +1,25 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Install Vercel CLI
+        run: npm install --global vercel
+      - name: Deploy Preview
+        run: vercel --token ${{ secrets.VERCEL_TOKEN }} --org ${{ secrets.VERCEL_ORG_ID }} --project ${{ secrets.VERCEL_PROJECT_ID }} --yes
+      - name: Deploy Production
+        if: github.ref == 'refs/heads/main'
+        run: vercel --prod --token ${{ secrets.VERCEL_TOKEN }} --org ${{ secrets.VERCEL_ORG_ID }} --project ${{ secrets.VERCEL_PROJECT_ID }} --yes
+      - name: Echo URL
+        run: |
+          echo "Deploy URL:" $(vercel ls --token ${{ secrets.VERCEL_TOKEN }} | head -n 1)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Codex-Playground
-Sandbox repo for playing around with Codex capabilities
+
+
+[![Pages](https://github.com/mtonsmann/Codex-Playground/actions/workflows/gh-pages.yml/badge.svg)](https://github.com/mtonsmann/Codex-Playground/actions/workflows/gh-pages.yml)
+[![Vercel](https://github.com/mtonsmann/Codex-Playground/actions/workflows/vercel.yml/badge.svg)](https://github.com/mtonsmann/Codex-Playground/actions/workflows/vercel.yml)
+
+Demo repo showing simple GitHub Pages and Vercel deployments.
+
+- **GitHub Pages:** https://mtonsmann.github.io/Codex-Playground/
+- **Vercel (prod):** https://<vercel-app>.vercel.app/
+
+## How this works
+1. Push to `main` triggers two GitHub Actions workflows.
+2. `gh-pages.yml` uploads the repo contents as a Pages artifact and deploys using GitHub's official `deploy-pages` action.
+3. `vercel.yml` installs the Vercel CLI and deploys a preview on every push.
+4. When the push is on `main`, the same job also deploys to production using the `--prod` flag.
+5. Each workflow finishes by printing the deployed URL for quick access.
+
+## Secrets & security
+- Create a Vercel token under your Vercel account settings.
+- Scope the token to the desired organization and project IDs.
+- Add `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` to your GitHub repository secrets so the workflows can authenticate without exposing credentials.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+    <style>
+        body {
+            display: flex;
+            height: 100vh;
+            justify-content: center;
+            align-items: center;
+            font-family: sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <h1>Hello world – deployed via GitHub Pages!</h1>
+</body>
+</html>

--- a/vercel-demo/package.json
+++ b/vercel-demo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vercel-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/vercel-demo/pages/index.js
+++ b/vercel-demo/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Hello from Vercel</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple GitHub Pages site and workflow
- scaffold minimal Next.js app with Vercel deployment workflow
- document how this works with CI/CD and secrets
- update README with repo owner
- tidy index.html style
- switch to official GitHub Pages action

## Testing
- `node --version`
- `npm install next react react-dom` in `vercel-demo`


------
https://chatgpt.com/codex/tasks/task_e_6879bfa3e610832b94ccbc873225a40f