### PR TITLE
Fix Pages workflow failing due to deprecated artifact action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
   deploy:
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update `configure-pages` action to v5
- update `upload-pages-artifact` action to v3
- update `deploy-pages` action to v4

These updates avoid the `actions/upload-artifact: v3` deprecation error.

## Testing
- `npm test` *(fails: could not read package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6879ee6134dc832bbacfc3e39a288bfc